### PR TITLE
Fix generator_output flag

### DIFF
--- a/lib/gyp.js
+++ b/lib/gyp.js
@@ -526,10 +526,10 @@ gyp.main = function main(args) {
     genFlags = genFlags.concat(shlexEnv('GYP_GENERATOR_FLAGS'));
   if (options.generator_flags)
     genFlags = genFlags.concat(options.generator_flags);
-  const generatorFlags = nameValueListToDict(genFlags);
+  options.generator_flags = nameValueListToDict(genFlags);
   if (gyp.debug[DEBUG_GENERAL]) {
     debugOutput(DEBUG_GENERAL,
-                'generator flags: %j', generatorFlags);
+                'generator flags: %j', options.generator_flags);
   }
 
   // Generate ninja!

--- a/lib/gyp/generator/ninja/index.js
+++ b/lib/gyp/generator/ninja/index.js
@@ -483,7 +483,9 @@ function NinjaMain(targetList, targetDicts, data, params, config) {
 
   this.options = params.options;
 
-  this.genDir = path.relative(this.options.generatorOutput || '.', '.');
+  this.genDir = this.options.generator_output || '.'
+  if (!path.isAbsolute(this.genDir))
+    this.genDir = path.relative(this.genDir, '.');
   this.outDir = path.normalize(path.join(
       this.genDir,
       this.options.generator_flags && this.options.generator_flags.output_dir ||


### PR DESCRIPTION
I'm working on a `node-gyp` fork that uses `gyp.js`:  https://github.com/pmed/node-gyp/tree/gyp.js

Here is 2 fixes. First one updates `options.generator_flags` with an object, parsed from `-Gname=value` command options.

Second fix prevents resolving of `generator_output` in case of absolute path (such a path is generated with `node-gyp configure`)