### PR TITLE
Fix external_dep gyppie test on Windows

### DIFF
--- a/test/gyppies/external_dep/lib.h
+++ b/test/gyppies/external_dep/lib.h
@@ -1,5 +1,1 @@
-#ifdef _WIN32
-/* Windows - set up dll import/export decorators. */
-__declspec(dllimport)
-#endif
 int hello();


### PR DESCRIPTION
Removed __declspec(dllimport) for  a function in static library.
Such dllimort/dllexport specifications are required only for shared libraries.