### PR TITLE
ninja: fix for `generator_flags.output_dir`

### DIFF
--- a/lib/gyp/generator/ninja/index.js
+++ b/lib/gyp/generator/ninja/index.js
@@ -86,13 +86,6 @@ function Ninja(options) {
   const targetName = parsed.target;
   const toolset = parsed.toolset;
 
-  // Use path, relative to the --depth=...
-  const buildFile = gyp.common.cachedRelative(options.genDir, parsed.buildFile);
-
-  let obj = 'obj';
-  if (toolset !== 'target')
-    obj += '.' + toolset;
-
   this.index = options.index;
   this.ninjas = options.ninjas;
   this.config = options.config;
@@ -101,10 +94,23 @@ function Ninja(options) {
   this.toolset = toolset;
   this.targetDict = options.targetDict;
 
-  this.outDir = options.outDir;
-  this.intDir = path.dirname(buildFile);
-  this.objDir = common.path.join(this.outDir, obj, this.intDir);
-  this.srcDir = path.dirname(buildFile);
+  // Main output directory
+  this.configDir = options.configDir;
+
+  // Source files paths are relative to the directory of .gyp file
+  this.srcDir = path.dirname(parsed.buildFile);
+
+  // Postfix for INTERMEDIATE_DIR
+  // TODO(indutny): this should not have `..` in it, should we assert?
+  this.intPostfix = this.srcDir;
+
+  // Directory to place objects
+  let obj = 'obj';
+  if (toolset !== 'target')
+    obj += '.' + toolset;
+  this.objDir = common.path.join(this.configDir, obj, this.intPostfix);
+
+  // If there are any C++ source files - this one will be set to `true`
   this.useCxx = false;
 
   const filename = common.path.join(this.objDir, targetName) + '.ninja';
@@ -125,7 +131,7 @@ Ninja.prototype.expand = function expand(p, productDir) {
 
   // TODO(indutny): verify this
   if (/\$!INTERMEDIATE_DIR/g.test(p)) {
-    const intDir = common.path.join(productDir, this.intDir, 'gen');
+    const intDir = common.path.join(productDir, this.intPostfix, 'gen');
     p = p.replace(/\$!INTERMEDIATE_DIR/g, intDir);
   }
 
@@ -145,7 +151,7 @@ Ninja.prototype.srcPath = function srcPath(p) {
   p = this.expand(p);
   if (path.isAbsolute(p))
     return p;
-  return gyp.common.cachedRelative(this.outDir,
+  return gyp.common.cachedRelative(this.configDir,
                                    common.path.join(this.srcDir, p));
 };
 
@@ -386,8 +392,8 @@ Ninja.prototype.actions = function actions() {
   list.forEach((action) => {
     const actionRule = action.action_name + '_' + this.index;
 
-    const base = gyp.common.cachedRelative(this.outDir, this.srcDir);
-    const toBase = gyp.common.cachedRelative(this.srcDir, this.outDir);
+    const base = gyp.common.cachedRelative(this.configDir, this.srcDir);
+    const toBase = gyp.common.cachedRelative(this.srcDir, this.configDir);
 
     this.n.rule(actionRule, {
       description: action.message,
@@ -445,7 +451,7 @@ Ninja.prototype.generate = function generate() {
     const objPath = common.path.join(this.objDir,
       path.isAbsolute(originalSource)? '' : path.dirname(originalSource),
       objBasename);
-    const obj = gyp.common.cachedRelative(this.outDir, objPath);
+    const obj = gyp.common.cachedRelative(this.configDir, objPath);
     const rule = isWinASM ? 'asm' : cxx ? 'cxx' : 'cc';
 
     this.n.build(rule, [ obj ], [ source ], {
@@ -512,13 +518,19 @@ function NinjaMain(targetList, targetDicts, data, params, config) {
 
   this.options = params.options;
 
-  this.genDir = this.options.generator_output || '.';
-  if (!path.isAbsolute(this.genDir))
-    this.genDir = path.relative(this.genDir, '.');
-  this.outDir = path.normalize(common.path.join(
-      this.genDir,
+  // Output directory: generator_output/g.output_dir
+  this.outDir = this.options.generator_output || '.';
+  if (!path.isAbsolute(this.outDir))
+    this.outDir = path.relative('.', this.outDir);
+
+  const outputPostfix =
       this.options.generator_flags && this.options.generator_flags.output_dir ||
-          'out'));
+      'out';
+
+  this.outDir = common.path.join(this.outDir, outputPostfix);
+  this.outDir = path.normalize(this.outDir);
+
+  // Configuration directory: outDir/config-name (out/Default)
   this.configDir = common.path.join(this.outDir, this.config);
 
   this.n = new Writer(common.path.join(this.configDir, 'build.ninja'));
@@ -658,8 +670,8 @@ NinjaMain.prototype.rulesAndTargets = function rulesAndTargets() {
   const ninjaList = this.targetList.map((target, index) => {
     const ninja = new Ninja({
       index: index,
-      genDir: this.genDir,
-      outDir: this.configDir,
+      outDir: this.outDir,
+      configDir: this.configDir,
       target: target,
       targetDict: this.targetDicts[target].configurations[this.config],
       ninjas: ninjas,

--- a/test/gyppies-test.js
+++ b/test/gyppies-test.js
@@ -23,7 +23,10 @@ function build(name) {
     const stdio = [ null, null, 'inherit' ];
     const spawnOpts = { stdio: stdio, cwd: folder };
 
-    let p = spawnSync(process.execPath, [ gyp ], spawnOpts);
+    const argvFile = path.join(folder, 'argv.json');
+    const argv = fs.existsSync(argvFile) ? require(argvFile) : [];
+
+    let p = spawnSync(process.execPath, [ gyp ].concat(argv), spawnOpts);
     if (p.status !== 0 && p.stdout)
       console.error(p.stdout.toString());
     if (p.error)

--- a/test/gyppies/generator_output/argv.json
+++ b/test/gyppies/generator_output/argv.json
@@ -1,0 +1,1 @@
+[ "--generator-output=out", "-Goutput_dir=." ]

--- a/test/gyppies/generator_output/main.c
+++ b/test/gyppies/generator_output/main.c
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/test/gyppies/generator_output/test.gyp
+++ b/test/gyppies/generator_output/test.gyp
@@ -1,0 +1,9 @@
+{
+  "targets": [{
+    "target_name": "test",
+    "type": "executable",
+    "sources": [
+      "main.c",
+    ],
+  }],
+}


### PR DESCRIPTION
Put sanity back into `ninja`'s directory structures, many of them were
confusing and the names differ through the file.

Fix: #24 

cc @pmed @springmeyer