### PR TITLE
ninja: prefer clang/clang++ defaults for freebsd

### DIFF
--- a/lib/gyp/generator/ninja/index.js
+++ b/lib/gyp/generator/ninja/index.js
@@ -564,7 +564,7 @@ NinjaMain.prototype.vars = function vars() {
   let ar = 'ar';
   let ld;
   let ldxx;
-  if (process.platform === 'darwin') {
+  if (process.platform === 'darwin' || process.platform === 'freebsd') {
     cc = 'clang';
     cxx = 'clang++';
   } else if (process.platform === 'win32') {


### PR DESCRIPTION
Clang/Clang++ has been the default compiler from FreeBSD 9 and forward.

Also, I'd like to raise an issue to led me to this change:
In the `make_global_settings` test the [environment is overridden](https://github.com/indutny/gyp.js/blob/master/test/gyppies/make_global_settings/test.gyp#L3..L6) to avoid compilation. This won't work in places where env is set (`setenv CC clang`) since it
always have preference.

I didn't patch it since I'm not sure how you would like to prefer defaults but let me know and I'll fix it.