### PR TITLE
Add code coverage to spawned gyp jobs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ SRC_FILES+= test/**/*.js
 SRC_FILES+= test/**/**/*.js
 
 BINDIR=./node_modules/.bin
+COVERAGEDIR=./coverage
 
 lint:
 	@$(BINDIR)/eslint $(SRC_FILES)
@@ -21,7 +22,10 @@ check:
 	@$(BINDIR)/mocha --reporter=spec test/*-test.js
 
 coverage:
-	@$(BINDIR)/istanbul cover --html $(BINDIR)/_mocha -- -u exports -R spec test/*-test.js
+	@-rm -rf $(COVERAGEDIR)
+	@$(BINDIR)/istanbul cover --report none --print none --include-pid \
+		$(BINDIR)/_mocha -- -u exports -R spec test/*-test.js
+	@$(BINDIR)/istanbul report text-summary lcov
 
 test: check
 


### PR DESCRIPTION
This PR adds coverage information for spawned instances of gyp to the coverage report.

It slows down the execution of tests when coverage is run, so it might trigger the mocha slow threshold more often now, not sure if that's a concern...

(My Makefile-ing is not great, so I'm not sure if this is an idiomatic way to handle that?)

Just if it's of any use :-)