### PR TITLE
gyp: export GYP_ENGINE/GYP_ENGINE_VERSION

### DIFF
--- a/src/gyp.js
+++ b/src/gyp.js
@@ -83,6 +83,9 @@ function load(options, extra) {
   defaultVariables['GENERATOR'] = format;
   defaultVariables['GENERATOR_FLAVOR'] = params['flavor'] || '';
 
+  defaultVariables['GYP_ENGINE'] = 'gyp.js';
+  defaultVariables['GYP_ENGINE_VERSION'] = require('../package.json').version;
+
   /* Format can be a custom JS file, or by default the name of a module
    * within gyp.generator.
    */

--- a/test/gyppies/engine_vars/main.c
+++ b/test/gyppies/engine_vars/main.c
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/test/gyppies/engine_vars/test.gyp
+++ b/test/gyppies/engine_vars/test.gyp
@@ -1,0 +1,13 @@
+{
+  "targets": [{
+    "target_name": "test",
+    "type": "executable",
+    "conditions": [
+      [ "GYP_ENGINE == 'gyp.js' and GYP_ENGINE_VERSION != ''", {
+        "sources": [
+          "main.c",
+        ],
+      }],
+    ],
+  }],
+}


### PR DESCRIPTION
`gyp.js` has a bit different semantics when it comes to placement of the
output files. To be able to build node `node.gyp` will have to be
modified to account for this. In such case, additional dependence on
particular GYP engine will be needed.

`GYP_ENGINE` and `GYP_ENGINE_VERSION` are two variables that will help
maintainers to add such dependence and make the project universally
buildable.

----------

@refack I'm sorry to CC you, please let me know if you don't want to be bothered with this anymore. So far you have expressed the most interest in this project, though!

Do you think this is a right thing to do?